### PR TITLE
Make anaconda_tamer timeout quicker

### DIFF
--- a/anaconda_tamer/anaconda_tamer.sh
+++ b/anaconda_tamer/anaconda_tamer.sh
@@ -11,5 +11,9 @@ else
     exit 1
 fi
 
-
-ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "root@$HOST" "tmux attach-session -d -t anaconda"
+# connect to a remote server with specific options useful for development
+#
+# StrictHostKeyChecking -- do not check that ssh public key changed (public key is not persistent between reboots)
+# UserKnownHostsFile -- do not store public key of the VM (public key is not persistent between reboots)
+# ServerAliveInterval -- make the timeout time smaller (in case you will reboot machine which you are connected to)
+ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 "root@$HOST" "tmux attach-session -d -t anaconda"


### PR DESCRIPTION
If you forget to detach ssh from the anaconda installation before reboot you will wait a long time before timeout.

This change will make the timeout smaller (something above 10 sec).

Also make better commenting of the options.