### PR TITLE
Add option to include other update images

### DIFF
--- a/anaconda_updates/anaconda_updates/settings.py
+++ b/anaconda_updates/anaconda_updates/settings.py
@@ -22,6 +22,7 @@ class GlobalSettings(object):
     # None means use branch specific
     target = None
     add_addon = []
+    add_image = []
     image_name = None
 
     add_RPM = []


### PR DESCRIPTION
With this, the Anaconda updates script can now merge other images, such as from add-ons in development.