### PR TITLE
anaconda-tamer: Use install user instead of root

### DIFF
--- a/anaconda_tamer/anaconda_tamer.sh
+++ b/anaconda_tamer/anaconda_tamer.sh
@@ -16,4 +16,4 @@ fi
 # StrictHostKeyChecking -- do not check that ssh public key changed (public key is not persistent between reboots)
 # UserKnownHostsFile -- do not store public key of the VM (public key is not persistent between reboots)
 # ServerAliveInterval -- make the timeout time smaller (in case you will reboot machine which you are connected to)
-ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 "root@$HOST" "tmux attach-session -d -t anaconda"
+ssh -t -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=5 "install@$HOST"


### PR DESCRIPTION
The install user will automatically connect us to tmux which will make everything easier.