### PR TITLE
Do not require access to the server if tag is set

### DIFF
--- a/anaconda_updates/update_image.py
+++ b/anaconda_updates/update_image.py
@@ -111,7 +111,6 @@ class CreateCommand(object):
             cmd.append("-t")
             cmd.append("HEAD")
         else:
-            version = self._branch_obj.version
             input_args = self._branch_obj.input_args
 
             if compile:
@@ -132,6 +131,7 @@ class CreateCommand(object):
             if GlobalSettings.target:
                 commit_version = GlobalSettings.target
             else:
+                version = self._branch_obj.version
                 commit_version = "anaconda-" + version + "-1"
 
             cmd.append("-t")


### PR DESCRIPTION
Tag has a priority over getting version from server so there is no reason to slow process by contacting server.