### PR TITLE
Enable qemu console to be able to send key to the VM

### DIFF
--- a/reanaconda/README.md
+++ b/reanaconda/README.md
@@ -18,3 +18,9 @@ $ ./reanaconda.py updates path/to/updates.img
 $ # or: echo updates.img | entr -r ./scripts/reanaconda updates updates.img
 $ ./reanaconda.py cleanup
 ```
+
+# Notes
+
+To switch TTY the QEMU console will automatically connect to the
+terminal with reanaconda. You can switch console by writing
+'sendkey ctrl-alt-f1'.

--- a/reanaconda/reanaconda.py
+++ b/reanaconda/reanaconda.py
@@ -54,6 +54,7 @@ QEMU_SENSIBLE_ARGUMENTS = [
     '-object', 'rng-random,id=rng0,filename=/dev/urandom',
     '-device', 'virtio-rng-pci,rng=rng0',
     '-drive', 'file=reanaconda/disk.img,cache=unsafe,if=virtio',
+    '-monitor', 'stdio',
 ]
 
 


### PR DESCRIPTION
We need to send keys to VM to be able to switch TTY there. With this change the QEMU console will attach to terminal and you can pass commands in it. This console will exit automatically when VM is turned off.