### PR TITLE
Add SSH forwarding to reanaconda

### DIFF
--- a/reanaconda/reanaconda.py
+++ b/reanaconda/reanaconda.py
@@ -157,7 +157,7 @@ class QEMU:
             print('to ssh into the VM, execute')
             print('  ssh -o StrictHostKeyChecking=no '
                   '-o UserKnownHostsFile=/dev/null '
-                  f'root@localhost -p {self.ssh_port}')
+                  f'anaconda@localhost -p {self.ssh_port}')
         subprocess.run(cmd, check=True)
 
     def monitor_execute(self, cmd, wait=True):


### PR DESCRIPTION
If there was '--append inst.sshd' during priming,
forward SSH and display a command to connect to it during the updates phase.

@jkonecny12
