### PR TITLE
Add workflow for building daily boot.iso

### DIFF
--- a/.github/workflows/daily-boot-iso.yml
+++ b/.github/workflows/daily-boot-iso.yml
@@ -1,0 +1,42 @@
+name: Build daily Rawhide+COPR boot.iso
+on:
+  #schedule:
+  #  - cron: 0 0 * * *
+  # be able to start this action manually from a actions tab when needed
+  workflow_dispatch:
+
+jobs:
+  boot_iso:
+    name: Build boot.iso
+    runs-on: ubuntu-latest
+    steps:
+      # lorax and its dependencies do not exist in Ubuntu, and we want to test the latest Fedora version anyway
+      # lorax does mounts and uses loop devices, thus needs to be privileged
+      - name: Start fedora container
+        run: |
+          mkdir data
+          docker run --name fedora -d --privileged --network host -v $PWD/data:/data fedora:latest sleep infinity
+
+      - name: Install lorax
+        run: docker exec fedora dnf install -y lorax
+
+      - name: Run lorax
+        run: docker exec -w /data fedora lorax -p Fedora -v 34 -r 34 -s http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ -s https://download.copr.fedorainfracloud.org/results/rpmsoftwaremanagement/dnf-nightly/fedora-rawhide-x86_64/ -s https://download.copr.fedorainfracloud.org/results/@rhinstaller/Anaconda/fedora-rawhide-x86_64/ -s https://copr-be.cloud.fedoraproject.org/results/@storage/blivet-daily/fedora-rawhide-x86_64/ /data/results
+
+      - name: Make generated files accessible
+        run: docker exec fedora chmod -R a+rX /data/
+
+      - name: Upload log artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs
+          path: |
+            data/*.log
+            data/*.txt
+
+      - name: Upload image artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: images
+          path: |
+            data/results/**


### PR DESCRIPTION
This replaces the ad-hoc upshift instance "nightly_iso_builder" and the Jenkins job "daily_boot_iso". There is nothing secret going on here, this does not even need any secrets, so it's fine to let this run on public infra in GitHub.

With that, kickstart-tests running anywhere can make use of the latest daily boot.iso (even though they will need a GitHub token to be allowed to *download* the zip artifact) - i.e. we don't restrict access to that to just upshift any more. Developers can just as easily download/use it in a local test run.

I will send a corresponding PoC PR to kickstart-tests to show that the full chain works.

 - [ ] Decide where to actually put this workflow (this repo is fine? or kickstart-tests?)
 - [ ] Uncomment/add schedule for appropriate time
 - [ ] Agree how to consume this; https://github.com/rhinstaller/kickstart-tests/pull/402 provides a PoC with the runner container launch script