### PR TITLE
Use real paths to Python site packages

### DIFF
--- a/anaconda_updates/anaconda_updates/releases/__init__.py
+++ b/anaconda_updates/anaconda_updates/releases/__init__.py
@@ -50,7 +50,8 @@ class GeneralBranch(object):
                  blivet_args=[],
                  pykickstart_args=[],
                  simpleline_args=[],
-                 dasbus_args=[]):
+                 dasbus_args=[],
+                 site_packages="./run/install/updates/"):
 
         self.type = branch_type
         self.cmd_args = cmd_args
@@ -63,6 +64,7 @@ class GeneralBranch(object):
         self.simpleline_args = simpleline_args
         self.dasbus_args = dasbus_args
         self.show_version_params = version_script_params
+        self.site_packages = site_packages
 
     @property
     def version(self):

--- a/anaconda_updates/anaconda_updates/releases/master.py
+++ b/anaconda_updates/anaconda_updates/releases/master.py
@@ -6,4 +6,5 @@ class MasterBranch(GeneralBranch):
     def __init__(self):
         super().__init__(branch_type=Branch.master,
                          cmd_args=["-m", "--master"], help="working on Rawhide",
-                         version_script_params=["-m", "-p"])
+                         version_script_params=["-m", "-p"],
+                         site_packages="./usr/lib/python3.9/site-packages/")

--- a/anaconda_updates/update_image.py
+++ b/anaconda_updates/update_image.py
@@ -155,7 +155,7 @@ class Executor(object):
         try:
             os.makedirs(os.path.join(
                 GlobalSettings.anaconda_path,
-                "updates/run/install/updates"
+                "updates"
             ))
         except os.error as e:
             print("Updates directory exists already")
@@ -198,40 +198,50 @@ class Executor(object):
             except FileExistsError as e:
                 print("Can't copy addon")
 
+        site_packages_path = os.path.join(
+            GlobalSettings.anaconda_path,
+            "updates",
+            branch.site_packages
+        )
+
         if GlobalSettings.use_blivet:
             print("Copy blivet...")
             source = os.path.join(GlobalSettings.projects_path, "blivet/blivet")
-            dest = os.path.join(GlobalSettings.anaconda_path, "updates/run/install/updates/blivet")
+            dest = os.path.join(site_packages_path, "blivet")
             try:
+                os.makedirs(site_packages_path, exist_ok=True)
                 shutil.copytree(source, dest)
-            except FileExistsError as e:
+            except OSError as e:
                 print("Skipping blivet copy:", str(e))
 
         if GlobalSettings.use_pykickstart:
             print("Copy pykickstart...")
             source = os.path.join(GlobalSettings.projects_path, "pykickstart/pykickstart")
-            dest = os.path.join(GlobalSettings.anaconda_path, "updates/run/install/updates/pykickstart")
+            dest = os.path.join(site_packages_path, "pykickstart")
             try:
+                os.makedirs(site_packages_path, exist_ok=True)
                 shutil.copytree(source, dest)
-            except FileExistsError as e:
+            except OSError as e:
                 print("Skipping pykickstart copy:", str(e))
 
         if GlobalSettings.use_simpleline:
             print("Copy simpleline...")
             source = os.path.join(GlobalSettings.projects_path, "simpleline/simpleline")
-            dest = os.path.join(GlobalSettings.anaconda_path, "updates/run/install/updates/simpleline")
+            dest = os.path.join(site_packages_path, "simpleline")
             try:
+                os.makedirs(site_packages_path, exist_ok=True)
                 shutil.copytree(source, dest)
-            except FileExistsError as e:
+            except OSError as e:
                 print("Skipping dasbus copy:", str(e))
 
         if GlobalSettings.use_dasbus:
             print("Copy dasbus...")
             source = os.path.join(GlobalSettings.projects_path, "dasbus/dasbus")
-            dest = os.path.join(GlobalSettings.anaconda_path, "updates/run/install/updates/dasbus")
+            dest = os.path.join(site_packages_path, "dasbus")
             try:
+                os.makedirs(site_packages_path, exist_ok=True)
                 shutil.copytree(source, dest)
-            except FileExistsError as e:
+            except OSError as e:
                 print("Skipping simpleline copy:", str(e))
 
     def create_updates_img(self, command):


### PR DESCRIPTION
Anaconda is not going to support Python site packages in `/run/install/updates`.

**Related to:** https://github.com/rhinstaller/anaconda/pull/3127 (but it doesn't depend on it)