### PR TITLE
Add support for Fedora 35

### DIFF
--- a/anaconda_updates/anaconda_updates/releases/__init__.py
+++ b/anaconda_updates/anaconda_updates/releases/__init__.py
@@ -1,6 +1,6 @@
 __all__ = ["Branch", "GeneralBranch", "master",
            "f22", "f23", "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31", "f32", "f33",
-           "f34",
+           "f34", "f35",
            "rhel6", "rhel6_8",
            "rhel7", "rhel7_1", "rhel7_2", "rhel7_3", "rhel7_4", "rhel7_5", "rhel7_6",
            "rhel8", "rhel9"]
@@ -29,6 +29,7 @@ class Branch(Enum):
     fedora32 = 12,
     fedora33 = 13,
     fedora34 = 14,
+    fedora35 = 15,
 
     rhel6    = 50,
     rhel6_8  = 51,

--- a/anaconda_updates/anaconda_updates/releases/f34.py
+++ b/anaconda_updates/anaconda_updates/releases/f34.py
@@ -7,5 +7,5 @@ class Fedora34Branch(GeneralBranch):
         super().__init__(branch_type=Branch.fedora34,
                          cmd_args=["-f34", "--fedora34"],
                          help="working on Fedora 34",
-                         version_script_params=["-f34", "-p"],
+                         version="34.24.9",
                          site_packages="./usr/lib/python3.9/site-packages/")

--- a/anaconda_updates/anaconda_updates/releases/f35.py
+++ b/anaconda_updates/anaconda_updates/releases/f35.py
@@ -1,0 +1,11 @@
+from . import GeneralBranch, Branch
+
+
+class Fedora35Branch(GeneralBranch):
+
+    def __init__(self):
+        super().__init__(branch_type=Branch.fedora35,
+                         cmd_args=["-f35", "--fedora35"],
+                         help="working on Fedora 35",
+                         version_script_params=["-f35", "-p"],
+                         site_packages="./usr/lib/python3.10/site-packages/")

--- a/anaconda_updates/anaconda_updates/releases/master.py
+++ b/anaconda_updates/anaconda_updates/releases/master.py
@@ -7,4 +7,4 @@ class MasterBranch(GeneralBranch):
         super().__init__(branch_type=Branch.master,
                          cmd_args=["-m", "--master"], help="working on Rawhide",
                          version_script_params=["-m", "-p"],
-                         site_packages="./usr/lib/python3.9/site-packages/")
+                         site_packages="./usr/lib/python3.10/site-packages/")

--- a/anaconda_updates/scripts/show_version.sh
+++ b/anaconda_updates/scripts/show_version.sh
@@ -74,6 +74,10 @@ do
          PACKAGES_URL="fedora34/Packages/a"
          shift
          ;;
+        -f35)
+         PACKAGES_URL="fedora35/Packages/a"
+         shift
+         ;;
         -p)
          VERSION_ONLY=true
          shift


### PR DESCRIPTION
Also, set fixed version for F34.

~~DO NOT MERGE YET, DOES NOT WORK YET. The site-packages path is wrong on the f35-devel & -release branches of anaconda repo.~~