### PR TITLE
Use the latest tag if the Anaconda version cannot be detected

### DIFF
--- a/anaconda_updates/anaconda_updates/releases/__init__.py
+++ b/anaconda_updates/anaconda_updates/releases/__init__.py
@@ -67,17 +67,18 @@ class GeneralBranch(object):
     def version(self):
         if self._version:
             return self._version
-        else:
-            ver = self.get_version()
-            if not ver:
-                raise ValueError("Anaconda version is not known")
 
-            return ver
+        return self._get_version()
 
     def add_argument(self, parse_args):
         parse_args.add_branch_param(*self.cmd_args, const_val=self.type,
                                     help=self.help)
 
-    def get_version(self):
+    def _get_version(self):
+        if not GlobalSettings.show_version_script_path:
+            print("There is no script for detection of the Anaconda version.")
+            return None
+
         path = os.path.expanduser(GlobalSettings.show_version_script_path)
-        return subprocess.check_output([path, *self.show_version_params]).decode()[:-1]
+        version = subprocess.check_output([path, *self.show_version_params]).decode()[:-1]
+        return version

--- a/anaconda_updates/anaconda_updates/settings.py
+++ b/anaconda_updates/anaconda_updates/settings.py
@@ -14,7 +14,7 @@ class GlobalSettings(object):
     server = None         # Server with PXE which you are using to test anaconda; could be None
     server_path = "~"     # Server path for saving updates image; default '~'
     local_path = "/tmp"   # Local path to the image; default "/tmp"
-    show_version_script_path = ""
+    show_version_script_path = None
 
     #######################
     # Run specific configuration
@@ -43,7 +43,7 @@ class GlobalSettings(object):
             config.read_file(f_cfg)
             global_settings = config["GlobalSettings"]
             cls.projects_path = global_settings["ProjectsPath"] # must be specified in config file
-            cls.show_version_script_path = global_settings["ShowVersionScriptPath"]
+            cls.show_version_script_path = global_settings.get("ShowVersionScriptPath", None)
             cls.anaconda_path = os.path.join(
                 cls.projects_path, global_settings.get("anaconda_pathName", "anaconda")
             )

--- a/anaconda_updates/update_image.py
+++ b/anaconda_updates/update_image.py
@@ -129,13 +129,16 @@ class CreateCommand(object):
                 input_args.extend(["-a", rpm])
 
             if GlobalSettings.target:
-                commit_version = GlobalSettings.target
+                cmd.extend(["-t", GlobalSettings.target])
             else:
                 version = self._branch_obj.version
-                commit_version = "anaconda-" + version + "-1"
 
-            cmd.append("-t")
-            cmd.append(commit_version)
+                if version:
+                    commit_version = "anaconda-" + version + "-1"
+                    cmd.extend(["-t", commit_version])
+                else:
+                    print("Using the latest tag.")
+
             cmd.extend(input_args)
 
         return cmd


### PR DESCRIPTION
The `makeupdates` script is able to use the latest tag if it is run without
the `-t` option. However, the `update_image.py` doesn't support that and
tries to run the `show_version.sh` script to detect the version.

Let's change that and make the `show_version.sh` script optional:

* If the branch defines a specific Anaconda version, use it.
* If the script at `ShowVersionScriptPath` returns a version, use it.
* If there is no script or no version to use, use the latest tag.