### PR TITLE
Fix URL path for reanaconda

### DIFF
--- a/reanaconda/reanaconda.py
+++ b/reanaconda/reanaconda.py
@@ -63,6 +63,18 @@ CMDLINE_UPDATES = 'inst.updates=http://10.0.2.22/updates.img'
 CMDLINE_KICKSTART = 'inst.ks=http://10.0.2.22/kickstart'
 
 
+def check_dependencies():
+    ok = True
+    if not shutil.which("qemu-system-x86_64"):
+        print("'qemu-system-x86_64' needs to be installed!", file=sys.stderr)
+        ok = False
+    if not shutil.which("qemu-img"):
+        print("'qemu-img' needs to be installed!", file=sys.stderr)
+        ok = False
+
+    return ok
+
+
 class DaemonHTTPServer(http.server.HTTPServer, socketserver.ThreadingMixIn):
     daemon_threads = True
 
@@ -250,6 +262,9 @@ def cleanup():
 
 
 if __name__ == '__main__':
+    # early quit if dependencies are not installed in the system
+    check_dependencies()
+
     if len(sys.argv) < 2 or '--help' in sys.argv:
         print(__doc__)
         sys.exit(1)


### PR DESCRIPTION
The path to download installable tree is not correct so run of this tool will fail.

Unfortunately, I wasn't able to make it run even with this fix but at least it's closer to get it working so I'm proposing it anyway when I have it locally already.

There is also minor improvement for dependency checking.